### PR TITLE
Introduce two pid-related features

### DIFF
--- a/internal/bpflbr/bpf_tracing.go
+++ b/internal/bpflbr/bpf_tracing.go
@@ -28,6 +28,7 @@ func NewBPFTracing(spec *ebpf.CollectionSpec, reusedMaps map[string]*ebpf.Map, i
 	var cfg LbrConfig
 	cfg.SetSuppressLbr(suppressLbr)
 	cfg.SetOutputStack(outputFuncStack)
+	cfg.FilterPid = uint32(filterPid)
 
 	if err := spec.Variables["lbr_config"].Set(cfg); err != nil {
 		return nil, fmt.Errorf("failed to set lbr config: %w", err)

--- a/internal/bpflbr/flags.go
+++ b/internal/bpflbr/flags.go
@@ -18,6 +18,7 @@ const (
 	progFlagDescriptorPinned = "pinned"
 	progFlagDescriptorTag    = "tag"
 	progFlagDescriptorName   = "name"
+	progFlagDescriptorPid    = "pid"
 )
 
 const (
@@ -40,6 +41,7 @@ type ProgFlag struct {
 	pinned string
 	tag    string
 	name   string
+	pid    uint32
 
 	descriptor string
 	funcName   string
@@ -76,6 +78,16 @@ func parseProgFlag(p string) (ProgFlag, error) {
 		if pf.name == "" {
 			return pf, errors.New("name must not be empty")
 		}
+		return pf, nil
+
+	case "pid":
+		pf.descriptor = progFlagDescriptorPid
+		id, pf.funcName, _ = strings.Cut(funcName, ":")
+		pid, err := strconv.ParseUint(id, 10, 32)
+		if err != nil {
+			return pf, fmt.Errorf("failed to parse pid %s from %s: %w", funcName, p, err)
+		}
+		pf.pid = uint32(pid)
 		return pf, nil
 
 	default:
@@ -123,7 +135,7 @@ func ParseFlags() (*Flags, error) {
 	var flags Flags
 
 	f := flag.NewFlagSet("bpflbr", flag.ExitOnError)
-	f.StringSliceVarP(&flags.progs, "prog", "p", nil, "bpf prog info for bpflbr in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>'; all bpf progs will be traced by default")
+	f.StringSliceVarP(&flags.progs, "prog", "p", nil, "bpf prog info for bpflbr in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced by default")
 	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "kernel functions for bpflbr")
 	f.StringVarP(&flags.outputFile, "output", "o", "", "output file for the result, default is stdout")
 	f.BoolVar(&flags.disasm, "dump-jited", false, "dump native insn info of bpf prog, the one bpf prog must be provided by --prog (its function name will be ignored) [Deprecated, use --disasm instead]")

--- a/internal/bpflbr/flags.go
+++ b/internal/bpflbr/flags.go
@@ -32,6 +32,7 @@ var (
 
 	suppressLbr     bool
 	outputFuncStack bool
+	filterPid       uint32
 )
 
 type ProgFlag struct {
@@ -133,6 +134,7 @@ func ParseFlags() (*Flags, error) {
 	f.StringVarP(&mode, "mode", "m", TracingModeExit, "mode of lbr tracing, exit or entry")
 	f.BoolVar(&suppressLbr, "suppress-lbr", false, "suppress LBR perf event")
 	f.BoolVar(&outputFuncStack, "output-stack", false, "output function call stack")
+	f.Uint32Var(&filterPid, "filter-pid", 0, "filter pid for tracing")
 
 	return &flags, f.Parse(os.Args)
 }

--- a/internal/bpflbr/lbr_bpf_prog.go
+++ b/internal/bpflbr/lbr_bpf_prog.go
@@ -9,7 +9,8 @@ const (
 )
 
 type LbrConfig struct {
-	Flags uint32
+	Flags     uint32
+	FilterPid uint32
 }
 
 func (cfg *LbrConfig) SetSuppressLbr(v bool) {


### PR DESCRIPTION
1. Retrieve bpf progs of specified process by `-p pid:${pid}`.
2. Trace only for specified process by `--filter-pid ${pid}`.