### PR TITLE
Some misc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Usage of bpflbr:
   -d, --disasm                disasm bpf prog or kernel function
   -B, --disasm-bytes uint     disasm bytes of kernel function, must not 0
       --disasm-intel-syntax   use Intel asm syntax for disasm, ATT asm syntax by default
-      --dump-jited            dump native insn info of bpf prog, the one bpf prog must be provided by --prog (its function name will be ignored) [Deprecated, use --disasm instead]
   -k, --kfunc strings         kernel functions for bpflbr
   -m, --mode string           mode of lbr tracing, exit or entry (default "exit")
   -o, --output string         output file for the result, default is stdout

--- a/internal/bpflbr/bpf_tracing_info.go
+++ b/internal/bpflbr/bpf_tracing_info.go
@@ -15,6 +15,10 @@ type bpfTracingInfo struct {
 }
 
 func (p *bpfProgs) addTracing(id ebpf.ProgramID, funcName string, prog *ebpf.Program) error {
+	if prog.Type() == ebpf.Tracing {
+		return nil
+	}
+
 	key := fmt.Sprintf("%d:%s", id, funcName)
 	if _, ok := p.tracings[key]; ok {
 		return nil

--- a/internal/bpflbr/flags.go
+++ b/internal/bpflbr/flags.go
@@ -138,7 +138,6 @@ func ParseFlags() (*Flags, error) {
 	f.StringSliceVarP(&flags.progs, "prog", "p", nil, "bpf prog info for bpflbr in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced by default")
 	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "kernel functions for bpflbr")
 	f.StringVarP(&flags.outputFile, "output", "o", "", "output file for the result, default is stdout")
-	f.BoolVar(&flags.disasm, "dump-jited", false, "dump native insn info of bpf prog, the one bpf prog must be provided by --prog (its function name will be ignored) [Deprecated, use --disasm instead]")
 	f.BoolVarP(&flags.disasm, "disasm", "d", false, "disasm bpf prog or kernel function")
 	f.UintVarP(&flags.disasmBytes, "disasm-bytes", "B", 0, "disasm bytes of kernel function, must not 0")
 	f.BoolVar(&disasmIntelSyntax, "disasm-intel-syntax", false, "use Intel asm syntax for disasm, ATT asm syntax by default")

--- a/internal/bpflbr/lbr.go
+++ b/internal/bpflbr/lbr.go
@@ -215,6 +215,9 @@ func getFuncStack(event *Event, progs *bpfProgs, addr2line *Addr2Line, ksym *Kal
 	var data FuncStack
 	err := funcStacks.Lookup(id, &data)
 	if err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return stack, nil
+		}
 		return stack, fmt.Errorf("failed to lookup func stack map: %w", err)
 	}
 	_ = funcStacks.Delete(id)

--- a/internal/bpflbr/lbr.go
+++ b/internal/bpflbr/lbr.go
@@ -172,7 +172,7 @@ func getLbrStack(event *Event, progs *bpfProgs, addr2line *Addr2Line, ksyms *Kal
 
 		entries = entries[nrSkip:]
 
-		if isProg {
+		if isProg && mode == TracingModeExit {
 			for i := range entries {
 				if progInfo.contains(entries[i].From) || progInfo.contains(entries[i].To) {
 					entries = entries[i:]

--- a/internal/bpflbr/lbr_stack.go
+++ b/internal/bpflbr/lbr_stack.go
@@ -15,15 +15,19 @@ type branchEndpoint struct {
 	offset       uintptr
 	endpointName string // ${funcName}+${offset}
 
-	fileName string
-	fileLine uint32
-	lineInfo string // (${fileName}:${fileLine})
-	isProg   bool
+	fileName    string
+	fileLine    uint32
+	lineInfo    string // (${fileName}:${fileLine})
+	isProg      bool
 	fromVmlinux bool
 }
 
 func (b *branchEndpoint) updateInfo() {
-	b.endpointName = fmt.Sprintf("%#x:%s+%#x", b.addr, b.funcName, b.offset)
+	if verbose {
+		b.endpointName = fmt.Sprintf("%#x:%s+%#x", b.addr, b.funcName, b.offset)
+	} else {
+		b.endpointName = fmt.Sprintf("%s+%#x", b.funcName, b.offset)
+	}
 	if b.fileName != "" {
 		b.lineInfo = fmt.Sprintf("(%s:%d)", b.fileName, b.fileLine)
 	}


### PR DESCRIPTION
1. Remove deprecated `--dump-jited` option.
2. Ignore `ErrKeyNotExist` when fail to lookup `func_stacks` map.
3. Skip tracing bpf progs as they can't be traced.
4. Enhance output LBR/function stack when verbose and when not verbose.