### PR TITLE
Filter kernel functions by shell wildcards way

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ Usage of bpflbr:
   -d, --disasm                disasm bpf prog or kernel function
   -B, --disasm-bytes uint     disasm bytes of kernel function, must not 0
       --disasm-intel-syntax   use Intel asm syntax for disasm, ATT asm syntax by default
-  -k, --kfunc strings         kernel functions for bpflbr
+      --filter-pid uint32     filter pid for tracing
+  -k, --kfunc strings         filter kernel functions by shell wildcards way
+      --kfunc-all-kmods       filter functions in all kernel modules
   -m, --mode string           mode of lbr tracing, exit or entry (default "exit")
   -o, --output string         output file for the result, default is stdout
       --output-stack          output function call stack
-  -p, --prog strings          bpf prog info for bpflbr in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>'; all bpf progs will be traced by default
+  -p, --prog strings          bpf prog info for bpflbr in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced by default
       --suppress-lbr          suppress LBR perf event
   -v, --verbose               output verbose log
 ```
@@ -86,7 +88,7 @@ Usage of bpflbr:
       xlated 7544B  jited 3997B  memlock 12288B  map_ids 5449,5446,5447,5451,5450,5448,5444
       btf_id 6017
 
-# ./bpflbr -p 4483 --dump-jited
+# ./bpflbr -p 4483 --disasm
 ; bpf/kprobe_pwru.c:532:0 PWRU_ADD_KPROBE(3)
 0xffffffffc00c0e64: 0f 1f 44 00 00        nopl  (%rax, %rax)
 0xffffffffc00c0e69: 66 90                 nop
@@ -96,7 +98,7 @@ Usage of bpflbr:
 ...
 
 # echo "If want to show intel asm syntax"
-# BPFLBR_DUMP_INTEL_SYNTAX=1 ./bpflbr -p 4483 --dump-jited
+# ./bpflbr -p 4483 --disasm --disasm-intel-syntax
 ; bpf/kprobe_pwru.c:532:0 PWRU_ADD_KPROBE(3)
 0xffffffffc00bde9c: 0f 1f 44 00 00        nop   dword ptr [rax + rax]
 0xffffffffc00bdea1: 66 90                 nop
@@ -153,8 +155,6 @@ Func stack:
 
 ## TODO list
 
-- [ ] Develop `bpflbr` feature to filter kernel function with regexp.
-- [ ] Develop `bpflbr` feature to trace kernel functions with kprobe.multi, [bpf: Add multi kprobe link](https://github.com/torvalds/linux/commit/0dcac2725406).
 - [ ] Develop `bpflbr` feature to trace userspace functions with uretprobe (**HELP WANTED**).
 
 ## Acknowledgments

--- a/bpf/lbr.c
+++ b/bpf/lbr.c
@@ -4,6 +4,8 @@
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
 
+__u32 ready SEC(".data.ready") = 0;
+
 #define MAX_LBR_ENTRIES 32
 
 struct lbr_config {
@@ -48,6 +50,9 @@ emit_lbr_event(void *ctx)
     struct event *event;
     __u64 retval;
     __u32 cpu;
+
+    if (!ready)
+        return BPF_OK;
 
     cpu = bpf_get_smp_processor_id();
     event = &lbr_events[cpu];

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.4
 require (
 	github.com/Asphaltt/addr2line v0.1.0
 	github.com/cilium/ebpf v0.16.1-0.20241204125435-9895aae6467e
+	github.com/gobwas/glob v0.2.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/knightsc/gapstone v4.0.1+incompatible
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cilium/ebpf v0.16.1-0.20241204125435-9895aae6467e h1:5XfglRYfkpOngOCO
 github.com/cilium/ebpf v0.16.1-0.20241204125435-9895aae6467e/go.mod h1:vay2FaYSmIlv3r8dNACd4mW/OCaZLJKJOo+IHBvCIO8=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/internal/bpflbr/flags.go
+++ b/internal/bpflbr/flags.go
@@ -34,6 +34,7 @@ var (
 	suppressLbr     bool
 	outputFuncStack bool
 	filterPid       uint32
+	kfuncAllKmods   bool
 )
 
 type ProgFlag struct {
@@ -137,6 +138,7 @@ func ParseFlags() (*Flags, error) {
 	f := flag.NewFlagSet("bpflbr", flag.ExitOnError)
 	f.StringSliceVarP(&flags.progs, "prog", "p", nil, "bpf prog info for bpflbr in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced by default")
 	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "filter kernel functions by shell wildcards way")
+	f.BoolVar(&kfuncAllKmods, "kfunc-all-kmods", false, "filter functions in all kernel modules")
 	f.StringVarP(&flags.outputFile, "output", "o", "", "output file for the result, default is stdout")
 	f.BoolVarP(&flags.disasm, "disasm", "d", false, "disasm bpf prog or kernel function")
 	f.UintVarP(&flags.disasmBytes, "disasm-bytes", "B", 0, "disasm bytes of kernel function, must not 0")

--- a/internal/bpflbr/flags.go
+++ b/internal/bpflbr/flags.go
@@ -136,7 +136,7 @@ func ParseFlags() (*Flags, error) {
 
 	f := flag.NewFlagSet("bpflbr", flag.ExitOnError)
 	f.StringSliceVarP(&flags.progs, "prog", "p", nil, "bpf prog info for bpflbr in format PROG[,PROG,..], PROG: PROGID[:<prog function name>], PROGID: <prog ID> or 'i/id:<prog ID>' or 'p/pinned:<pinned file>' or 't/tag:<prog tag>' or 'n/name:<prog full name>' or 'pid:<pid>'; all bpf progs will be traced by default")
-	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "kernel functions for bpflbr")
+	f.StringSliceVarP(&flags.kfuncs, "kfunc", "k", nil, "filter kernel functions by shell wildcards way")
 	f.StringVarP(&flags.outputFile, "output", "o", "", "output file for the result, default is stdout")
 	f.BoolVarP(&flags.disasm, "disasm", "d", false, "disasm bpf prog or kernel function")
 	f.UintVarP(&flags.disasmBytes, "disasm-bytes", "B", 0, "disasm bytes of kernel function, must not 0")

--- a/internal/bpflbr/kernel_functions.go
+++ b/internal/bpflbr/kernel_functions.go
@@ -6,6 +6,7 @@ package bpflbr
 import (
 	"fmt"
 	"log"
+	"os"
 	"slices"
 
 	"github.com/cilium/ebpf/btf"
@@ -43,25 +44,44 @@ func FindKernelFuncs(funcs []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	kernelBtf, err := btf.LoadKernelSpec()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load kernel BTF: %w", err)
-	}
-
 	kfuncs := make([]string, 0, len(funcs))
 
-	iter := kernelBtf.Iterate()
-	for iter.Next() {
-		if fn, ok := iter.Type.(*btf.Func); ok && isGlobFunc(fn.Name, globs) {
-			funcProto := fn.Type.(*btf.FuncProto)
-			if len(funcProto.Params) <= MAX_BPF_FUNC_ARGS {
-				kfuncs = append(kfuncs, fn.Name)
-			} else if verbose {
-				log.Printf("Skip function %s with %d args because of limit %d args\n",
-					fn.Name, len(funcProto.Params), MAX_BPF_FUNC_ARGS)
+	iterBtfSpec := func(spec *btf.Spec) {
+		iter := spec.Iterate()
+		for iter.Next() {
+			if fn, ok := iter.Type.(*btf.Func); ok && isGlobFunc(fn.Name, globs) {
+				funcProto := fn.Type.(*btf.FuncProto)
+				if len(funcProto.Params) <= MAX_BPF_FUNC_ARGS {
+					kfuncs = append(kfuncs, fn.Name)
+				} else if verbose {
+					log.Printf("Skip function %s with %d args because of limit %d args\n",
+						fn.Name, len(funcProto.Params), MAX_BPF_FUNC_ARGS)
+				}
 			}
 		}
+	}
+
+	if kfuncAllKmods {
+		files, err := os.ReadDir("/sys/kernel/btf")
+		if err != nil {
+			return nil, fmt.Errorf("failed to read /sys/kernel/btf: %w", err)
+		}
+
+		for _, file := range files {
+			kmodBtf, err := btf.LoadKernelModuleSpec(file.Name())
+			if err != nil {
+				return nil, fmt.Errorf("failed to load kernel module BTF: %w", err)
+			}
+
+			iterBtfSpec(kmodBtf)
+		}
+	} else {
+		kernelBtf, err := btf.LoadKernelSpec()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load kernel BTF: %w", err)
+		}
+
+		iterBtfSpec(kernelBtf)
 	}
 
 	slices.Sort(kfuncs)

--- a/internal/bpflbr/kernel_functions.go
+++ b/internal/bpflbr/kernel_functions.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Leon Hwang.
+// SPDX-License-Identifier: Apache-2.0
+
+package bpflbr
+
+import (
+	"fmt"
+	"log"
+	"slices"
+
+	"github.com/cilium/ebpf/btf"
+	"github.com/gobwas/glob"
+)
+
+const (
+	MAX_BPF_FUNC_ARGS = 12
+)
+
+func str2glob(funcs []string) ([]glob.Glob, error) {
+	globs := make([]glob.Glob, 0, len(funcs))
+	for _, fn := range funcs {
+		g, err := glob.Compile(fn)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile glob from %s: %w", fn, err)
+		}
+
+		globs = append(globs, g)
+	}
+	return globs, nil
+}
+
+func isGlobFunc(fn string, globs []glob.Glob) bool {
+	for _, g := range globs {
+		if g.Match(fn) {
+			return true
+		}
+	}
+	return false
+}
+
+func FindKernelFuncs(funcs []string) ([]string, error) {
+	globs, err := str2glob(funcs)
+	if err != nil {
+		return nil, err
+	}
+
+	kernelBtf, err := btf.LoadKernelSpec()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kernel BTF: %w", err)
+	}
+
+	kfuncs := make([]string, 0, len(funcs))
+
+	iter := kernelBtf.Iterate()
+	for iter.Next() {
+		if fn, ok := iter.Type.(*btf.Func); ok && isGlobFunc(fn.Name, globs) {
+			funcProto := fn.Type.(*btf.FuncProto)
+			if len(funcProto.Params) <= MAX_BPF_FUNC_ARGS {
+				kfuncs = append(kfuncs, fn.Name)
+			} else if verbose {
+				log.Printf("Skip function %s with %d args because of limit %d args\n",
+					fn.Name, len(funcProto.Params), MAX_BPF_FUNC_ARGS)
+			}
+		}
+	}
+
+	slices.Sort(kfuncs)
+	kfuncs = slices.Compact(kfuncs)
+
+	return kfuncs, nil
+}

--- a/main.go
+++ b/main.go
@@ -116,6 +116,10 @@ func main() {
 	assert.NoErr(err, "Failed to create func_stacks map: %v")
 	defer funcStacks.Close()
 
+	readyDataMap, err := ebpf.NewMap(bpfSpec.Maps[".data.ready"])
+	assert.NoErr(err, "Failed to create ready data map: %v")
+	defer readyDataMap.Close()
+
 	events, err := ebpf.NewMap(bpfSpec.Maps["events"])
 	assert.NoErr(err, "Failed to create events map: %v")
 	defer events.Close()
@@ -123,6 +127,7 @@ func main() {
 	reusedMaps := map[string]*ebpf.Map{
 		"events":      events,
 		".data.lbrs":  lbrs,
+		".data.ready": readyDataMap,
 		"func_stacks": funcStacks,
 	}
 
@@ -152,6 +157,9 @@ func main() {
 		defer f.Close()
 		w = f
 	}
+
+	err = readyDataMap.Put(uint32(0), uint32(1))
+	assert.NoErr(err, "Failed to update ready data map: %v")
 
 	log.Print("bpflbr is running..")
 


### PR DESCRIPTION
Do some enhancements for kernel functions:

1. Filter kernel functions by shell wildcards way, like '*tcp_*rcv'.
2. Support tracing functions in kernel module.
3. Add 'ready' global variable to wait for user space being ready.