### PR TITLE
disasm: Guess function size

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ make
 # ./bpflbr -h
 Usage of bpflbr:
   -d, --disasm                disasm bpf prog or kernel function
-  -B, --disasm-bytes uint     disasm bytes of kernel function, must not 0
+  -B, --disasm-bytes uint     disasm bytes of kernel function, 0 to guess it automatically
       --disasm-intel-syntax   use Intel asm syntax for disasm, ATT asm syntax by default
       --filter-pid uint32     filter pid for tracing
   -k, --kfunc strings         filter kernel functions by shell wildcards way

--- a/internal/bpflbr/flags.go
+++ b/internal/bpflbr/flags.go
@@ -141,7 +141,7 @@ func ParseFlags() (*Flags, error) {
 	f.BoolVar(&kfuncAllKmods, "kfunc-all-kmods", false, "filter functions in all kernel modules")
 	f.StringVarP(&flags.outputFile, "output", "o", "", "output file for the result, default is stdout")
 	f.BoolVarP(&flags.disasm, "disasm", "d", false, "disasm bpf prog or kernel function")
-	f.UintVarP(&flags.disasmBytes, "disasm-bytes", "B", 0, "disasm bytes of kernel function, end at the very first retq/int3 insn or limit to 4096 if not provided")
+	f.UintVarP(&flags.disasmBytes, "disasm-bytes", "B", 0, "disasm bytes of kernel function, 0 to guess it automatically")
 	f.BoolVar(&disasmIntelSyntax, "disasm-intel-syntax", false, "use Intel asm syntax for disasm, ATT asm syntax by default")
 	f.BoolVarP(&verbose, "verbose", "v", false, "output verbose log")
 	f.StringVarP(&mode, "mode", "m", TracingModeExit, "mode of lbr tracing, exit or entry")


### PR DESCRIPTION
It's to enhance previous commmit by guessing function size instead of limiting 4096 blindly.

As ELF does not provide function size, it is OK to find next symbol and then the function size would be kaddr of next symbol minus current kaddr. And, trim the meaningless tailing int3 and nop insns.