### PR TITLE
Skip lbr entries on demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ BPF_OBJ := lbr_bpfel.o lbr_bpfeb.o feat_bpfel.o feat_bpfeb.o
 BPF_SRC := bpf/lbr.c bpf/feature.c
 
 BPFLBR_OBJ := bpflbr
+BPFLBR_SRC := $(shell find internal -type f -name '*.go') main.go
 BPFLBR_CSM := $(BPFLBR_OBJ).sha256sum
 RELEASE_NOTES ?= release_notes.txt
 
@@ -27,7 +28,7 @@ RELEASE_NOTES ?= release_notes.txt
 $(BPF_OBJ): $(BPF_SRC)
 	$(GOGEN)
 
-$(BPFLBR_OBJ): $(BPF_OBJ)
+$(BPFLBR_OBJ): $(BPF_OBJ) $(BPFLBR_SRC)
 	$(GOBUILD_CGO_LDFLAGS) $(GOBUILD)
 
 .PHONY: local_release

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The colorful output of `./bpflbr -v -k ip_rcv --suppress-lbr --output-stack`:
 - [ ] Filter kernel functions by their argument's name.
 - [ ] Filter function argument with [bice](https://github.com/leonhwangprojects/bice).
 - [ ] Output function argument's metadata dynamically like the way of `bice`.
+- [ ] Filter skb/xdp data with [pcap-filter(7)](https://www.tcpdump.org/manpages/pcap-filter.7.html).
 
 ## Acknowledgments
 


### PR DESCRIPTION
It's to avoid skipping 14 LBR entries blindly.

Because in v6.11 kernel, the LBR entries about `bpf_get_bransh_snopshot()` helper have been reduced from 7 to 2.