### PR TITLE
disasm: Fix showing bpf prog func info

### DIFF
--- a/internal/bpflbr/disasm.go
+++ b/internal/bpflbr/disasm.go
@@ -13,9 +13,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Asphaltt/bpflbr/internal/assert"
 	"github.com/fatih/color"
 	"github.com/knightsc/gapstone"
+
+	"github.com/Asphaltt/bpflbr/internal/assert"
 )
 
 const (
@@ -158,7 +159,7 @@ func dumpKfunc(kfunc string, bytes uint) {
 	}
 
 	VerboseLog("Disassembling bpf progs ..")
-	bpfProgs, err := NewBPFProgs(nil, false, true)
+	bpfProgs, err := NewBPFProgs([]ProgFlag{{all: true}}, false, true)
 	assert.NoErr(err, "Failed to get bpf progs: %v")
 	defer bpfProgs.Close()
 

--- a/internal/bpflbr/dump.go
+++ b/internal/bpflbr/dump.go
@@ -64,7 +64,7 @@ func DumpProg(pf []ProgFlag) {
 	defer engine.Close()
 
 	VerboseLog("Disassembling bpf progs ..")
-	bpfProgs, err := NewBPFProgs(nil, false, true)
+	bpfProgs, err := NewBPFProgs([]ProgFlag{{all: true}}, false, true)
 	assert.NoErr(err, "Failed to get bpf progs: %v")
 	defer bpfProgs.Close()
 


### PR DESCRIPTION
It fails to find bpf prog func info because it does not prepare those info.

Mark `all = true` to collect all bpf progs' func info.